### PR TITLE
Remove implementation of coroutine scope in generated services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ _2018-\*\*-\*\*_
 * Fix: Remove redundant usages of `@ObsoleteCoroutinesApi` in call builders
 * Fix: Remove unused experimental class `CompletableDeferredObserver`
 * Fix: Annotate `SuspendingUnaryObserver` as an internal API 
-* Fix: Remove unnecessary creation of `CoroutineScope` in `newSendChannelFromObserver` 
+* Fix: Remove unnecessary creation of `CoroutineScope` in `newSendChannelFromObserver`
+* New: Introduce `ServiceScope` interface and remove `CoroutineScope` from generated service classes
 * New: Use `Message.getDefaultInstance()` as default value of stub request parameters
 * Deprecated: Legacy service stub rpc builders in favor of new back-pressure supporting stub APIs  
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ stub.sayHello { name = "John" }
       * ```CoroutineName``` set to ```MethodDescriptor.fullMethodName```
       * ```GrpcContextElement``` set to ```io.grpc.Context.current()```
     * Base services implement ```CoroutineScope``` only as a means to allow overriding the initial ```coroutineContext```
-    * The initial ```coroutineContext``` defaults to ```Dispatchers.Default```
+    * The initial ```coroutineContext``` defaults to ```EmptyCoroutineContext```
     * A common case for overriding the default context is for setting up application specific ```ThreadContextElement``` or ```CoroutineDispatcher```, such as ```MDCContext()``` or ```newFixedThreadPoolContext(...)```
     * Rpc method implementation **MUST** be wrapped in a ```coroutineScope{}``` builder. Future versions of Kotlin will show a warning in the ide for ambiguous scope resolution. [KT-27493](https://youtrack.jetbrains.com/issue/KT-27493). It also ensures that the proper ```coroutineContext``` is used during method execution.
 

--- a/README.md
+++ b/README.md
@@ -149,11 +149,8 @@ _Server_
 ```kotlin
 override suspend fun sayHelloClientStreaming(
     requestChannel: ReceiveChannel<HelloRequest>
-): HelloReply = coroutineScope {
-
-    HelloReply {
-        message = requestChannel.toList().joinToString()
-    }
+): HelloReply =  HelloReply {
+    message = requestChannel.toList().joinToString()
 }
 ```
  
@@ -172,8 +169,7 @@ _Server_
 override suspend fun sayHelloServerStreaming(
     request: HelloRequest,
     responseChannel: SendChannel<HelloReply>
-) = coroutineScope {
-        
+) {        
     for(char in request.name) {
         responseChannel.send {
             message = "Hello $char!"
@@ -204,13 +200,10 @@ override suspend fun sayHelloStreaming(
     requestChannel: ReceiveChannel<HelloRequest>,
     responseChannel: SendChannel<HelloReply>
 ) {
-    coroutineScope {
+    requestChannel.mapTo(responseChannel){
     
-        requestChannel.mapTo(responseChannel){
-        
-            HelloReply {
-                message = "Hello there, ${it.name}!"
-            }
+        HelloReply {
+            message = "Hello there, ${it.name}!"
         }
     }
 }

--- a/example-project/src/main/proto/test/message/nested_messages.proto
+++ b/example-project/src/main/proto/test/message/nested_messages.proto
@@ -5,6 +5,15 @@ package validate.test;
 option java_package = "test.message";
 option java_outer_classname = "NestedMessages";
 
+message TestMessage {
+    string name = 1;
+    oneof something {
+        string something_a = 2;
+        bool something_b = 3;
+        int32 something_c = 4;
+    }
+}
+
 message L1Message1{
 
     string field = 1;

--- a/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/server/CoroutineService.kt
+++ b/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/server/CoroutineService.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Kroto+ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.marcoferrer.krotoplus.coroutines.server
+
+import kotlin.coroutines.CoroutineContext
+
+interface CoroutineService {
+
+    val initialContext: CoroutineContext
+
+}

--- a/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/server/ServerCalls.kt
+++ b/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/server/ServerCalls.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.*
 import java.util.concurrent.atomic.AtomicBoolean
 
 
-public fun <ReqT, RespT> CoroutineService.serverCallUnary(
+public fun <ReqT, RespT> ServiceScope.serverCallUnary(
     methodDescriptor: MethodDescriptor<ReqT, RespT>,
     responseObserver: StreamObserver<RespT>,
     block: suspend () -> RespT
@@ -40,7 +40,7 @@ public fun <ReqT, RespT> CoroutineService.serverCallUnary(
     }
 }
 
-public fun <ReqT, RespT> CoroutineService.serverCallServerStreaming(
+public fun <ReqT, RespT> ServiceScope.serverCallServerStreaming(
     methodDescriptor: MethodDescriptor<ReqT, RespT>,
     responseObserver: StreamObserver<RespT>,
     block: suspend (SendChannel<RespT>) -> Unit
@@ -59,7 +59,7 @@ public fun <ReqT, RespT> CoroutineService.serverCallServerStreaming(
 }
 
 @UseExperimental(ExperimentalCoroutinesApi::class)
-public fun <ReqT, RespT> CoroutineService.serverCallClientStreaming(
+public fun <ReqT, RespT> ServiceScope.serverCallClientStreaming(
     methodDescriptor: MethodDescriptor<ReqT, RespT>,
     responseObserver: StreamObserver<RespT>,
     block: suspend (ReceiveChannel<ReqT>) -> RespT
@@ -94,7 +94,7 @@ public fun <ReqT, RespT> CoroutineService.serverCallClientStreaming(
 
 
 @UseExperimental(ExperimentalCoroutinesApi::class)
-public fun <ReqT, RespT> CoroutineService.serverCallBidiStreaming(
+public fun <ReqT, RespT> ServiceScope.serverCallBidiStreaming(
     methodDescriptor: MethodDescriptor<ReqT, RespT>,
     responseObserver: StreamObserver<RespT>,
     block: suspend (ReceiveChannel<ReqT>, SendChannel<RespT>) -> Unit

--- a/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/server/ServiceScope.kt
+++ b/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/server/ServiceScope.kt
@@ -18,7 +18,7 @@ package com.github.marcoferrer.krotoplus.coroutines.server
 
 import kotlin.coroutines.CoroutineContext
 
-interface CoroutineService {
+interface ServiceScope {
 
     val initialContext: CoroutineContext
 

--- a/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/call/CallExtsTests.kt
+++ b/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/call/CallExtsTests.kt
@@ -178,6 +178,9 @@ class NewManagedServerResponseChannelTests {
         }
     }
 
+    //TODO: Verify number of requests being made to test back pressure
+
+
     @Test
     fun `Test manual flow control is enabled`() {
         GlobalScope.newManagedServerResponseChannel<Unit,Unit>(observer,AtomicBoolean()).close()

--- a/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/client/ClientCallClientStreamingTests.kt
+++ b/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/client/ClientCallClientStreamingTests.kt
@@ -211,6 +211,7 @@ class ClientCallClientStreamingTests {
                     }
                     assertFailsWithStatus(Status.CANCELLED) {
                         repeat(3) {
+                            delay(5)
                             requestChannel.send(
                                 HelloRequest.newBuilder()
                                     .setName(it.toString())
@@ -221,6 +222,7 @@ class ClientCallClientStreamingTests {
                 }
                 launch {
                     job.start()
+                    delay(5)
                     externalJob.cancel()
                 }
             }

--- a/protoc-gen-kroto-plus/generator-tests/build.gradle
+++ b/protoc-gen-kroto-plus/generator-tests/build.gradle
@@ -1,5 +1,13 @@
 apply plugin: 'com.google.protobuf'
 
+compileTestKotlin {
+    kotlinOptions {
+        freeCompilerArgs += [
+                "-Xuse-experimental=kotlin.Experimental"
+        ]
+    }
+}
+
 dependencies{
 
     testImplementation "io.mockk:mockk:${Versions.mockk}"

--- a/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcCoroutinesGeneratorTests.kt
+++ b/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcCoroutinesGeneratorTests.kt
@@ -33,6 +33,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.BeforeTest
 
+@UseExperimental(ObsoleteCoroutinesApi::class)
 class GrpcCoroutinesGeneratorTests {
 
     @[Rule JvmField]

--- a/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcStubExtsGeneratorTests.kt
+++ b/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcStubExtsGeneratorTests.kt
@@ -28,6 +28,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
+@UseExperimental(ObsoleteCoroutinesApi::class)
 class GrpcStubExtsGeneratorTests {
 
     @[Rule JvmField]

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcCoroutinesGenerator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcCoroutinesGenerator.kt
@@ -113,7 +113,7 @@ object GrpcCoroutinesGenerator : Generator {
         val baseImplBuilder = TypeSpec.classBuilder(baseImplName)
             .addModifiers(KModifier.ABSTRACT)
             .addSuperinterface(CommonClassNames.bindableService)
-            .addSuperinterface(CommonClassNames.coroutineService)
+            .addSuperinterface(CommonClassNames.serviceScope)
             .addProperty(
                 PropertySpec
                     .builder("initialContext", CommonClassNames.coroutineContext)

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcCoroutinesGenerator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcCoroutinesGenerator.kt
@@ -113,10 +113,10 @@ object GrpcCoroutinesGenerator : Generator {
         val baseImplBuilder = TypeSpec.classBuilder(baseImplName)
             .addModifiers(KModifier.ABSTRACT)
             .addSuperinterface(CommonClassNames.bindableService)
-            .addSuperinterface(CommonClassNames.coroutineScope)
+            .addSuperinterface(CommonClassNames.coroutineService)
             .addProperty(
                 PropertySpec
-                    .builder("coroutineContext", CommonClassNames.coroutineContext)
+                    .builder("initialContext", CommonClassNames.coroutineContext)
                     .addModifiers(KModifier.OVERRIDE)
                     .getter(
                         FunSpec.getterBuilder()

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/utils/CommonNames.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/utils/CommonNames.kt
@@ -55,6 +55,7 @@ object CommonClassNames{
     val streamObserver: ClassName = ClassName("io.grpc.stub", "StreamObserver")
 
     val experimentalKrotoPlusCoroutinesApi = ClassName(krotoCoroutineLib, "ExperimentalKrotoPlusCoroutinesApi")
+    val coroutineService = ClassName("$krotoCoroutineLib.server", "CoroutineService")
 
     val listenableFuture = ClassName("com.google.common.util.concurrent", "ListenableFuture")
     val grpcContextElement = ClassName(krotoCoroutineLib,"GrpcContextElement")

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/utils/CommonNames.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/utils/CommonNames.kt
@@ -55,7 +55,7 @@ object CommonClassNames{
     val streamObserver: ClassName = ClassName("io.grpc.stub", "StreamObserver")
 
     val experimentalKrotoPlusCoroutinesApi = ClassName(krotoCoroutineLib, "ExperimentalKrotoPlusCoroutinesApi")
-    val coroutineService = ClassName("$krotoCoroutineLib.server", "CoroutineService")
+    val serviceScope = ClassName("$krotoCoroutineLib.server", "ServiceScope")
 
     val listenableFuture = ClassName("com.google.common.util.concurrent", "ListenableFuture")
     val grpcContextElement = ClassName(krotoCoroutineLib,"GrpcContextElement")


### PR DESCRIPTION
Implementing `CoroutineScope` in the generated services has proven to cause too many issues with ambiguous context /  scope resolution. 

Classes implementing `CoroutineScope` should have their life cycle bound to the start and stop of the unit of work they represent. Since service implementations generally have a life cycle that spans the life of the application, this makes them an Ill fit for implementing coroutine scope.

The original intent of implementing `CoroutineScope` was to give services a mechanism to provide an initial coroutine context for rpc calls. That initial context would be used to create a proper scope per rpc method invocation. 

This pr introduces a new interface for services to implement that will still allow configuration of the initial rpc context. It will also allow less error prone usages of coroutines in service instances