### PR TITLE
Update codegen to support malformed rpc method names

### DIFF
--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/ProtoBuildersGenerator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/ProtoBuildersGenerator.kt
@@ -27,7 +27,6 @@ import com.google.protobuf.DescriptorProtos
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED
 import com.google.protobuf.compiler.PluginProtos
 import com.squareup.kotlinpoet.*
-import org.jetbrains.kotlin.utils.sure
 
 object ProtoBuildersGenerator : Generator {
 
@@ -178,7 +177,7 @@ object ProtoBuildersGenerator : Generator {
             .filterNot { it.second.isMapEntry }
             .map { (fieldDescriptorProto, protoMessageForField) ->
 
-                val fieldNameCamelCase = camelCaseFieldName(fieldDescriptorProto.name)
+                val fieldNameCamelCase = fieldDescriptorProto.name.toUpperCamelCase()
                 val statementTemplate = "return this.%N(%T.newBuilder().apply(block).build())"
 
                 val funSpecBuilder = if (fieldDescriptorProto.label == LABEL_REPEATED)
@@ -242,12 +241,3 @@ object ProtoBuildersGenerator : Generator {
     private val ProtoFile.dslBuilderClassName: ClassName
         get() = ClassName(javaPackage, "${javaOuterClassname}DslBuilder")
 }
-
-private val camelCaseFieldName = { it: String ->
-    // We cant use CaseFormat.UPPER_CAMEL since
-    // protoc is lenient with malformed field names
-    if (it.contains("_"))
-        it.split("_").joinToString(separator = "") { it.capitalize() } else
-        it.capitalize()
-
-}.memoize()

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/proto/ProtoMethod.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/proto/ProtoMethod.kt
@@ -16,10 +16,8 @@
 
 package com.github.marcoferrer.krotoplus.proto
 
+import com.github.marcoferrer.krotoplus.utils.toUpperCamelCase
 import com.google.protobuf.DescriptorProtos
-import com.squareup.kotlinpoet.AnnotationSpec
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.asClassName
 import io.grpc.MethodDescriptor
 
 class ProtoMethod(
@@ -27,9 +25,12 @@ class ProtoMethod(
     val protoService: ProtoService
 ) : Schema.DescriptorWrapper {
 
-    val functionName = descriptorProto.name.decapitalize()
+    val functionName = descriptorProto.name.toUpperCamelCase().let{
+        if(descriptorProto.name.startsWith("_"))
+            "_$it" else it.decapitalize()
+    }
 
-    val methodDefinitionGetterName = "get${descriptorProto.name}Method"
+    val methodDefinitionGetterName = "get${descriptorProto.name.toUpperCamelCase()}Method"
 
     val requestType = protoService.protoFile.schema.protoTypes[descriptorProto.inputType]
         ?: throw IllegalStateException("${descriptorProto.inputType} was not found in schema type map.")

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/utils/StringCaseExts.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/utils/StringCaseExts.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Kroto+ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.marcoferrer.krotoplus.utils
+
+val upperCamelCase = { it: String ->
+    // We cant use CaseFormat.UPPER_CAMEL since
+    // protoc is lenient with malformed field names
+    if (it.contains("_"))
+        it.split("_").joinToString(separator = "") { it.capitalize() } else
+        it.capitalize()
+
+}.memoize()
+
+fun String.toUpperCamelCase(): String = upperCamelCase(this)

--- a/test-api/src/main/proto/message/test_messages.proto
+++ b/test-api/src/main/proto/message/test_messages.proto
@@ -83,3 +83,20 @@ message TestRepeated {
     repeated bytes bytes_field = 16;
     repeated L1Message1 message_field = 17;
 }
+
+
+service __MalformedService__ {
+
+    rpc say_hello (L1Message1) returns (L1Message2);
+
+    rpc sayHelloStreaming (stream L1Message1) returns (stream L1Message2);
+}
+
+service malformed_SERvice_2 {
+
+    rpc say_hello (L1Message1) returns (L1Message2);
+
+    rpc __sayHEloStr_eaming (stream L1Message1) returns (stream L1Message2);
+
+    rpc _____s_a_YH_EloStr_eaming____ (stream L1Message1) returns (stream L1Message2);
+}


### PR DESCRIPTION
This PR resolves https://github.com/marcoferrer/kroto-plus/issues/37