### PR TITLE
Empty object generation when using maps and multiple files.

### DIFF
--- a/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/ProtoBuildersGeneratorTests.kt
+++ b/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/ProtoBuildersGeneratorTests.kt
@@ -22,6 +22,7 @@ import io.grpc.examples.helloworld.HelloWorldProtoDslBuilder
 import io.grpc.examples.helloworld.orDefault
 import org.junit.Test
 import test.message.*
+import test.message.multi.MappedMessage
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
@@ -101,5 +102,17 @@ class ProtoBuildersGeneratorTests {
         assertEquals(message1.field, result.field)
         assertNotEquals(message1.nestedMessage, result.nestedMessage)
         assertEquals(message2.nestedMessage.field, result.nestedMessage.field)
+    }
+
+    @Test
+    fun `Test message map omission`() {
+        val key = "test"
+        val value = "value"
+
+        val message = MappedMessage {
+            putTheField(key, value)
+        }
+
+        assertEquals(message.theFieldMap[key], value)
     }
 }

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/ProtoBuildersGenerator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/ProtoBuildersGenerator.kt
@@ -155,7 +155,7 @@ object ProtoBuildersGenerator : Generator {
 
             fileSpecBuilder.addFunctions(buildNestedBuildersForMessage(protoType))
 
-            if (protoType.nestedMessageTypes.isNotEmpty()) {
+            if (protoType.nestedMessageTypes.filterNot { it.isMapEntry }.isNotEmpty()) {
                 addType(
                     TypeSpec.objectBuilder(protoType.name)
                         .buildFunSpecsForTypes(fileSpecBuilder, protoType.nestedMessageTypes)

--- a/test-api/src/main/proto/message/test_messages_multi.proto
+++ b/test-api/src/main/proto/message/test_messages_multi.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package validate.test;
+
+option java_package = "test.message.multi";
+option java_multiple_files = true;
+
+message MappedMessage {
+    map<string, string> the_field = 1;
+}
+
+message RegularMessage {
+    int32 the_field = 1;
+}


### PR DESCRIPTION
Hi! I started to use this library not too long ago, great work!

So, I ran into a strange duplicate class error when using the protobuf builders generator, and having `option java_multiple_files = true`, compilation would fail whenever I have a message with a mapped field:

```
Task :myapp:kaptKotlin FAILED
e: <path to app>/build/generated/source/proto/main/java/com/myapp/Mapped.java:9: error: duplicate class: com.myapp.Mapped
public  final class Mapped extends
```

I tracked down the error to a generated `object Mapped` with no elements. Looking into the code I realized that it was generated there, but the filter didn't take into account map definitions (as is in other places in the generator)

I tested it and seems to solve the issue, test pass, but I don't know if there's anything else I should change.