### PR TITLE
Bugfix for race condition in outbound flow control

### DIFF
--- a/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/call/FlowControl.kt
+++ b/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/call/FlowControl.kt
@@ -17,13 +17,15 @@
 package com.github.marcoferrer.krotoplus.coroutines.call
 
 import io.grpc.stub.CallStreamObserver
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import javafx.application.Application.launch
+import kotlinx.coroutines.*
+import kotlinx.coroutines.NonCancellable.isActive
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 internal fun <T> CallStreamObserver<*>.applyInboundFlowControl(
     targetChannel: Channel<T>,
@@ -41,7 +43,7 @@ internal fun <T> CallStreamObserver<*>.applyInboundFlowControl(
     }
 }
 
-internal fun <T> CoroutineScope.applyOutboundFlowControl(
+internal fun <T> CoroutineScope.applyOutboundFlowControl_minSynchronized(
         streamObserver: CallStreamObserver<T>,
         targetChannel: Channel<T>
 ){
@@ -80,6 +82,68 @@ internal fun <T> CoroutineScope.applyOutboundFlowControl(
                     isOutboundJobRunning.set(false)
                 }
             }
+        }
+    }
+}
+
+internal fun <T> CoroutineScope.applyOutboundFlowControl(
+    streamObserver: CallStreamObserver<T>,
+    targetChannel: Channel<T>
+){
+    ChannelToStreamObserverAdapter(targetChannel, streamObserver, this)
+}
+
+private class ChannelToStreamObserverAdapter<T>(private val sourceChannel: Channel<T>,
+                                                private val destStreamObserver: CallStreamObserver<T>,
+                                                private val coscope: CoroutineScope) {
+
+    private val isOutboundJobRunning = AtomicBoolean()
+    private var currentCont: Continuation<Unit>? = null
+
+    init {
+        destStreamObserver.setOnReadyHandler {
+            if(sourceChannel.isClosedForReceive)
+                destStreamObserver.completeSafely()
+            else if (destStreamObserver.isReady &&
+                    !sourceChannel.isClosedForReceive &&
+                    isOutboundJobRunning.compareAndSet(false, true)) {
+                coscope.launch(Dispatchers.Unconfined + CoroutineExceptionHandler { _, e ->
+                    destStreamObserver.completeSafely(e)
+                    sourceChannel.close(e)
+                }) {
+                    run()
+                }
+            }
+            else synchronized(this@ChannelToStreamObserverAdapter) {
+                currentCont?.resume(Unit)
+                currentCont = null
+            }
+        }
+    }
+
+    /**
+     * Dispatch messages from the [sourceChannel] to the [destStreamObserver]. This coroutine runs for the entire
+     * duration of the underlying call and suspends while either source is empty or destination is not ready.
+     */
+    private suspend fun run() {
+        val channelIterator = sourceChannel.iterator()
+        while (!sourceChannel.isClosedForReceive) {
+            if (!destStreamObserver.isReady) {
+                suspendCancellableCoroutine<Unit> {
+                    synchronized(this@ChannelToStreamObserverAdapter) {
+                        if (destStreamObserver.isReady)
+                            it.resume(Unit)
+                        else
+                            currentCont = it
+                    }
+                }
+            }
+            if (!channelIterator.hasNext())
+                break
+            destStreamObserver.onNext(channelIterator.next())
+        }
+        if (sourceChannel.isClosedForReceive) {
+            destStreamObserver.onCompleted()
         }
     }
 }

--- a/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/call/FlowControl.kt
+++ b/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/call/FlowControl.kt
@@ -21,14 +21,9 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.ChannelIterator
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.coroutines.Continuation
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
-
 
 internal fun <T> CallStreamObserver<*>.applyInboundFlowControl(
     targetChannel: Channel<T>,


### PR DESCRIPTION
A bidi stream call with a high throughput of messages can hang up.

This occurred reliably in a throughput test where 100000 messages of 1kB were transmitted over an in-process channel to a server and echoed back to the caller. With kroto plus, the message transfer gets simply stuck and never completes.

The root cause is a race condition in `FlowControl.kt applyOutboundFlowControl()`: Reading `streamObserver.isReady` and setting `isOutboundJobRunning` are not atomic, thus the `outBoundJob` can terminate and misses to be relaunched by an onReady-event.

Here I propose a minimally invasive fix though I also considered refactoring the coroutine to be long running - suspend while not ready and resume on ready. Please consider addressing this because the hangup is a deal breaker for my use case and most likely others as well.
