### PR TITLE
Fallback to codegen request when file filter is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ _\*\*-\*\*_
 * New: Update to Kotlin Coroutines `1.3.0`
 
 #### Protoc Plugin
-* Fix: If no file filter is defined, fallback to `CodeGeneratorRequest.fileToGenerateList` [PR-69](https://github.com/marcoferrer/kroto-plus/pull/69) 
+* Fix: If no file filter is defined, fallback to `CodeGeneratorRequest.fileToGenerateList` [PR-70](https://github.com/marcoferrer/kroto-plus/pull/70) 
 
 
 ## Version 0.5.0-RC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ _\*\*-\*\*_
 * New: Update to Kotlin `1.3.50`
 * New: Update to Kotlin Coroutines `1.3.0`
 
+#### Protoc Plugin
+* Fix: If no file filter is defined, fallback to `CodeGeneratorRequest.fileToGenerateList` [PR-69](https://github.com/marcoferrer/kroto-plus/pull/69) 
+
 
 ## Version 0.5.0-RC
 _2019-08-22_

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/ExtendableMessagesGenerator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/ExtendableMessagesGenerator.kt
@@ -17,7 +17,6 @@
 package com.github.marcoferrer.krotoplus.generators
 
 import com.github.marcoferrer.krotoplus.proto.ProtoMessage
-import com.github.marcoferrer.krotoplus.utils.matches
 import com.google.protobuf.compiler.PluginProtos
 
 object ExtendableMessagesGenerator : Generator {
@@ -35,7 +34,7 @@ object ExtendableMessagesGenerator : Generator {
 
                 for (options in context.config.extendableMessagesList) {
 
-                    if (!options.filter.matches(protoMessage.protoFile.name) || protoMessage.isMapEntry)
+                    if (!isFileToGenerate(protoMessage.protoFile.name, options.filter) || protoMessage.isMapEntry)
                         continue
 
                     val kpPackage = "com.github.marcoferrer.krotoplus.message"

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/Generator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/Generator.kt
@@ -17,7 +17,9 @@
 package com.github.marcoferrer.krotoplus.generators
 
 import com.github.marcoferrer.krotoplus.config.CompilerConfig
+import com.github.marcoferrer.krotoplus.config.FileFilter
 import com.github.marcoferrer.krotoplus.script.ScriptManager
+import com.github.marcoferrer.krotoplus.utils.getRegexFilter
 import com.google.protobuf.compiler.PluginProtos
 import com.squareup.kotlinpoet.FileSpec
 import java.io.File
@@ -43,6 +45,14 @@ interface Generator : () -> PluginProtos.CodeGeneratorResponse {
                 content = this@toResponseFileProto.toString()
             }
             .build()
+
+
+    fun isFileToGenerate(path: String, filter: FileFilter): Boolean =
+        if(filter == FileFilter.getDefaultInstance()) {
+            path in GrpcCoroutinesGenerator.context.request.fileToGenerateList
+        } else {
+            filter.getRegexFilter().matches(path)
+        }
 
     companion object {
         const val AutoGenerationDisclaimer =

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/Generator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/Generator.kt
@@ -49,7 +49,7 @@ interface Generator : () -> PluginProtos.CodeGeneratorResponse {
 
     fun isFileToGenerate(path: String, filter: FileFilter): Boolean =
         if(filter == FileFilter.getDefaultInstance()) {
-            path in GrpcCoroutinesGenerator.context.request.fileToGenerateList
+            path in context.request.fileToGenerateList
         } else {
             filter.getRegexFilter().matches(path)
         }
@@ -66,23 +66,18 @@ val ScriptTemplateWithArgs.context: GeneratorContext
 val ScriptManager.context: GeneratorContext
     get() = contextInstance
 
+internal lateinit var contextInstance: GeneratorContext
+    private set
+
 fun initializeContext(compilerConfig: CompilerConfig? = null) {
-    compilerConfigOverride = compilerConfig
-    contextInstance
-}
 
-private var compilerConfigOverride: CompilerConfig? = null
-
-private val contextInstance by lazy {
     val inputStream = System.getProperty("krotoplus.debug.request.src")
         ?.let { File(it).inputStream() }
         ?: System.`in`
 
     val protoRequest = PluginProtos.CodeGeneratorRequest.parseFrom(inputStream)
 
-    compilerConfigOverride
+    contextInstance = compilerConfig
         ?.let { GeneratorContext(protoRequest, config = it) }
         ?: GeneratorContext(protoRequest)
 }
-
-

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcCoroutinesGenerator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcCoroutinesGenerator.kt
@@ -16,6 +16,7 @@
 
 package com.github.marcoferrer.krotoplus.generators
 
+import com.github.marcoferrer.krotoplus.config.FileFilter
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.github.marcoferrer.krotoplus.generators.Generator.Companion.AutoGenerationDisclaimer
 import com.github.marcoferrer.krotoplus.proto.*
@@ -51,7 +52,6 @@ object GrpcCoroutinesGenerator : Generator {
     private val ProtoService.stubClassName: ClassName
             get() = ClassName(protoFile.javaPackage, outerObjectName, stubName)
 
-
     override fun invoke(): PluginProtos.CodeGeneratorResponse {
         val responseBuilder = PluginProtos.CodeGeneratorResponse.newBuilder()
 
@@ -61,7 +61,7 @@ object GrpcCoroutinesGenerator : Generator {
 
             for (options in context.config.grpcCoroutinesList) {
 
-                if (options.filter.matches(service.protoFile.name)) {
+                if (isFileToGenerate(service.protoFile.name,options.filter)) {
                     service.buildGrpcFileSpec()?.let {
                         responseBuilder.addFile(it.toResponseFileProto())
                     }

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcStubExtsGenerator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcStubExtsGenerator.kt
@@ -52,7 +52,8 @@ object GrpcStubExtsGenerator : Generator {
     class FileBuilder(val options: GrpcStubExtsGenOptions) {
 
         fun buildFile(service: ProtoService): PluginProtos.CodeGeneratorResponse.File? = with(service) {
-            if (!options.filter.matches(protoFile.name))
+
+            if (!isFileToGenerate(protoFile.name,options.filter))
                 return null
 
             val filename = "${name}RpcOverloads"

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/InsertionsGenerator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/InsertionsGenerator.kt
@@ -18,13 +18,11 @@ package com.github.marcoferrer.krotoplus.generators
 
 import com.github.marcoferrer.krotoplus.config.InsertionPoint
 import com.github.marcoferrer.krotoplus.config.InsertionsGenOptions
-import com.github.marcoferrer.krotoplus.generators.InsertionsGenerator.buildInsertions
 import com.github.marcoferrer.krotoplus.proto.*
 import com.github.marcoferrer.krotoplus.script.ScriptManager
 import com.github.marcoferrer.krotoplus.utils.addFile
 import com.github.marcoferrer.krotoplus.utils.funcName
 import com.github.marcoferrer.krotoplus.utils.key
-import com.github.marcoferrer.krotoplus.utils.matches
 import com.google.protobuf.compiler.PluginProtos
 
 object InsertionsGenerator : Generator {
@@ -39,12 +37,12 @@ object InsertionsGenerator : Generator {
         for (options in context.config.insertionsList) {
 
             for (protoFile in context.schema.protoFiles)
-                if (options.filter.matches(protoFile.name)) {
+                if (isFileToGenerate(protoFile.name,options.filter)) {
                     protoFile.buildInsertions(options, responseBuilder)
                 }
 
             for (protoType in context.schema.protoTypes.values)
-                if (options.filter.matches(protoType.protoFile.name)) {
+                if (isFileToGenerate(protoType.protoFile.name,options.filter)) {
                     protoType.buildInsertions(options, responseBuilder)
                 }
         }

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/MockServicesGenerator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/MockServicesGenerator.kt
@@ -21,7 +21,6 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.github.marcoferrer.krotoplus.generators.Generator.Companion.AutoGenerationDisclaimer
 import com.github.marcoferrer.krotoplus.proto.*
 import com.github.marcoferrer.krotoplus.utils.CommonClassNames
-import com.github.marcoferrer.krotoplus.utils.matches
 import com.google.protobuf.compiler.PluginProtos
 import com.squareup.kotlinpoet.*
 import io.grpc.BindableService
@@ -47,7 +46,7 @@ object MockServicesGenerator : Generator {
         context.schema.protoServices.forEach { service ->
 
             for (options in context.config.mockServicesList) {
-                if (options.filter.matches(service.protoFile.name)) {
+                if (isFileToGenerate(service.protoFile.name,options.filter)) {
                     //TODO: Need clean up from v0.1.0
                     service.buildFileSpec(options)?.let { fileSpecBuilder ->
 

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/ProtoBuildersGenerator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/ProtoBuildersGenerator.kt
@@ -41,7 +41,7 @@ object ProtoBuildersGenerator : Generator {
             .filter { it.protoMessages.isNotEmpty() }
             .forEach { protoFile ->
                 for (options in context.config.protoBuildersList) {
-                    if (options.filter.matches(protoFile.name))
+                    if(isFileToGenerate(protoFile.name,options.filter))
                         buildFileSpec(protoFile, options, responseBuilder)
                 }
             }
@@ -52,7 +52,7 @@ object ProtoBuildersGenerator : Generator {
             .filterNot { it.isMapEntry }
             .forEach { protoMessage ->
                 for (options in context.config.protoBuildersList) {
-                    if (options.filter.matches(protoMessage.protoFile.name))
+                    if (isFileToGenerate(protoMessage.protoFile.name,options.filter))
                         responseBuilder.addFile(protoMessage.buildDslInsertion())
                 }
             }

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/utils/FileFilterExts.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/utils/FileFilterExts.kt
@@ -44,4 +44,8 @@ fun FileFilter.getRegexFilter(): RegexFilter =
         )
     }
 
+@Deprecated(
+    "This method does not account for files requested for generation by protoc",
+    ReplaceWith("isFileToGenerate(path, filter)")
+)
 fun FileFilter.matches(path: String): Boolean = getRegexFilter().matches(path)

--- a/protoc-gen-kroto-plus/src/test/kotlin/FileFilterTest.kt
+++ b/protoc-gen-kroto-plus/src/test/kotlin/FileFilterTest.kt
@@ -20,6 +20,7 @@ import com.github.marcoferrer.krotoplus.config.FileFilter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@Suppress("DEPRECATION")
 class FileFilterTest {
 
     val testPaths = listOf(

--- a/protoc-gen-kroto-plus/src/test/kotlin/GeneratorTests.kt
+++ b/protoc-gen-kroto-plus/src/test/kotlin/GeneratorTests.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Kroto+ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.marcoferrer.krotoplus.utils
+
+import com.github.marcoferrer.krotoplus.config.FileFilter
+import com.github.marcoferrer.krotoplus.generators.Generator
+import com.github.marcoferrer.krotoplus.generators.GeneratorContext
+import com.google.protobuf.compiler.PluginProtos
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class GeneratorTests {
+
+
+    @Test
+    fun `isFileToGenerate falls back to codegen request when file filter is not provided`(){
+
+        val filePath = "src/test/a.proto"
+        val mockContext = GeneratorContext(
+            PluginProtos.CodeGeneratorRequest.newBuilder()
+                .addFileToGenerate(filePath)
+                .build()
+        )
+
+        val generator = object : Generator {
+            override val context: GeneratorContext = mockContext
+            override fun invoke(): PluginProtos.CodeGeneratorResponse { TODO() }
+        }
+
+        assert(generator.isFileToGenerate(filePath, FileFilter.getDefaultInstance()))
+    }
+
+    @Test
+    fun `isFileToGenerate ignores codegen request when file filter is provided`(){
+
+        val filePath = "src/test/a.proto"
+        val mockContext = GeneratorContext(
+            PluginProtos.CodeGeneratorRequest.newBuilder()
+                .addFileToGenerate(filePath)
+                .build()
+        )
+
+        val filter = FileFilter.newBuilder().addIncludePath("").build()
+
+        val generator = object : Generator {
+            override val context: GeneratorContext = mockContext
+            override fun invoke(): PluginProtos.CodeGeneratorResponse { TODO() }
+        }
+
+        assertFalse(generator.isFileToGenerate(filePath, filter))
+    }
+
+}


### PR DESCRIPTION
At the moment Kroto is ignoring what files are being requested for generation by protoc. The file filtering is purely based on whatever configuration is provided by users. 

In order to keep backwards compatibility, kroto should honor existing file filters. But in the event that a file filter is not defined we should fall back to checking the original list of files to generate in the codegen request.