### PR TITLE
Add newer jdks to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ jdk:
   - openjdk12
 dist: trusty
 sudo: false
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
 cache:
   directories:
     - $HOME/.gradle/caches/
@@ -21,8 +17,10 @@ before_cache:
 jobs:
   include:
     - name: Gradle Check
+      install:
+        - ./gradlew assemble
       script:
-        - ./gradlew clean check
-        - cd example-project && ./gradlew clean test
+        - ./gradlew check
+        - cd example-project && ./gradlew test
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk10
+  - openjdk11
 dist: trusty
 sudo: false
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ jdk:
   - openjdk8
   - openjdk10
   - openjdk11
+  - openjdk12
 dist: trusty
 sudo: false
 addons:
@@ -20,10 +21,8 @@ before_cache:
 jobs:
   include:
     - name: Gradle Check
-      install:
-        - ./gradlew assemble
       script:
-        - ./gradlew check
-        - cd example-project && ./gradlew test
+        - ./gradlew clean check
+        - cd example-project && ./gradlew clean test
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 _\*\*-\*\*_
 * New: Update to Kotlin `1.3.50`
 * New: Update to Kotlin Coroutines `1.3.0`
+* New: Update CI to execute tests against `jdk10`,`jdk11`,`jdk12`
+* New: Update to project gradle to `5.6.2`
 
 #### Protoc Plugin
 * Fix: If no file filter is defined, fallback to `CodeGeneratorRequest.fileToGenerateList` [PR-70](https://github.com/marcoferrer/kroto-plus/pull/70) 

--- a/example-project/gradle/wrapper/gradle-wrapper.properties
+++ b/example-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kroto-plus-coroutines/benchmark/build.gradle
+++ b/kroto-plus-coroutines/benchmark/build.gradle
@@ -10,6 +10,11 @@ compileKotlin {
 }
 
 dependencies {
+    // For jdk 9+ you need to include javax.annotations
+    // The reason is outlined in this grpc issue
+    // https://github.com/grpc/grpc-java/issues/4725
+    compileOnly("javax.annotation:javax.annotation-api:1.2")
+    
     implementation project(':kroto-plus-coroutines')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"

--- a/kroto-plus-coroutines/build.gradle
+++ b/kroto-plus-coroutines/build.gradle
@@ -22,7 +22,6 @@ compileKotlin {
 }
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
         freeCompilerArgs += experimentalFlags
     }
 }
@@ -38,6 +37,11 @@ dependencies {
     testImplementation "io.mockk:mockk:${Versions.mockk}"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}"
 
+    // For jdk 9+ you need to include javax.annotations
+    // The reason is outlined in this grpc issue
+    // https://github.com/grpc/grpc-java/issues/4725
+    testImplementation "javax.annotation:javax.annotation-api:1.2"
+    
     // Not included by default due to the following issue
     // https://github.com/Kotlin/kotlinx.coroutines/issues/1060
     // testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-debug:${Versions.coroutines}"

--- a/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/client/ClientCallClientStreamingTests.kt
+++ b/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/client/ClientCallClientStreamingTests.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.SendChannel
-import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking

--- a/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/client/ClientCallServerStreamingTests.kt
+++ b/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/client/ClientCallServerStreamingTests.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ReceiveChannel
-import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule

--- a/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/integration/BidiStreamingTests.kt
+++ b/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/integration/BidiStreamingTests.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.toList
-import kotlinx.coroutines.debug.DebugProbes
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking

--- a/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/server/ServerCallClientStreamingTests.kt
+++ b/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/server/ServerCallClientStreamingTests.kt
@@ -41,7 +41,6 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.toList
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking

--- a/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/server/ServerCallServerStreamingTests.kt
+++ b/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/server/ServerCallServerStreamingTests.kt
@@ -44,7 +44,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking

--- a/protoc-gen-kroto-plus/generator-tests/build.gradle
+++ b/protoc-gen-kroto-plus/generator-tests/build.gradle
@@ -10,7 +10,7 @@ compileTestKotlin {
 }
 
 dependencies{
-
+    
     testImplementation "com.google.api.grpc:proto-google-common-protos:${Versions.commonProto}"
     
     testImplementation "io.mockk:mockk:${Versions.mockk}"
@@ -27,6 +27,12 @@ dependencies{
     testImplementation project(':kroto-plus-message')
     testImplementation project(':kroto-plus-coroutines')
     testImplementation project(':kroto-plus-test')
+
+    // For jdk 9+ you need to include javax.annotations
+    // The reason is outlined in this grpc issue
+    // https://github.com/grpc/grpc-java/issues/4725
+    testImplementation("javax.annotation:javax.annotation-api:1.2")
+
 }
 
 protobuf {

--- a/test-api/grpc/build.gradle
+++ b/test-api/grpc/build.gradle
@@ -2,6 +2,11 @@ apply plugin: 'com.google.protobuf'
 apply plugin: 'java-library'
 
 dependencies{
+    // For jdk 9+ you need to include javax.annotations
+    // The reason is outlined in this grpc issue
+    // https://github.com/grpc/grpc-java/issues/4725
+    compileOnly("javax.annotation:javax.annotation-api:1.2")
+    
     compileOnly "com.google.api.grpc:proto-google-common-protos:${Versions.commonProto}"
 
     protobuf project(':test-api')


### PR DESCRIPTION
Configure travis to run tests against jdks 10, 11, and 12. Update project gradle version to `5.6.1`