### PR TITLE
Refactor stub extension generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@ _\*\*-\*\*_
 * Fix: If no file filter is defined, fallback to `CodeGeneratorRequest.fileToGenerateList` [PR-70](https://github.com/marcoferrer/kroto-plus/pull/70)
 * Fix: File filter is no longer ignored in stub extension generator 
 
-#### Proto Builders (DSL)
-* Fix: Empty object generation when using maps and multiple files. [PR-51](https://github.com/marcoferrer/kroto-plus/pull/51) Thanks to @sauldhernandez
-
 
 ## Version 0.5.0-RC
 _2019-08-22_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ _\*\*-\*\*_
 * New: Update to project gradle to `5.6.2`
 
 #### Protoc Plugin
-* Fix: If no file filter is defined, fallback to `CodeGeneratorRequest.fileToGenerateList` [PR-70](https://github.com/marcoferrer/kroto-plus/pull/70) 
+* Fix: If no file filter is defined, fallback to `CodeGeneratorRequest.fileToGenerateList` [PR-70](https://github.com/marcoferrer/kroto-plus/pull/70)
+* Fix: File filter is no longer ignored in stub extension generator 
+
+#### Proto Builders (DSL)
+* Fix: Empty object generation when using maps and multiple files. [PR-51](https://github.com/marcoferrer/kroto-plus/pull/51) Thanks to @sauldhernandez
 
 
 ## Version 0.5.0-RC

--- a/protoc-gen-kroto-plus/generator-tests/build.gradle
+++ b/protoc-gen-kroto-plus/generator-tests/build.gradle
@@ -27,7 +27,8 @@ dependencies{
     testImplementation project(':kroto-plus-message')
     testImplementation project(':kroto-plus-coroutines')
     testImplementation project(':kroto-plus-test')
-
+    testImplementation "io.mockk:mockk:${Versions.mockk}"
+    
     // For jdk 9+ you need to include javax.annotations
     // The reason is outlined in this grpc issue
     // https://github.com/grpc/grpc-java/issues/4725

--- a/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcStubExtsGeneratorTests.kt
+++ b/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcStubExtsGeneratorTests.kt
@@ -14,28 +14,46 @@
  * limitations under the License.
  */
 
+@file:UseExperimental(ExperimentalCoroutinesApi::class,ObsoleteCoroutinesApi::class)
+
 package com.github.marcoferrer.krotoplus.generators
 
 import com.github.marcoferrer.krotoplus.coroutines.launchProducerJob
 import com.github.marcoferrer.krotoplus.coroutines.withCoroutineContext
-import io.grpc.examples.helloworld.*
+import io.grpc.examples.helloworld.GreeterCoroutineGrpc
+import io.grpc.examples.helloworld.GreeterGrpc
+import io.grpc.examples.helloworld.HelloReply
+import io.grpc.examples.helloworld.HelloRequest
+import io.grpc.examples.helloworld.sayHello
+import io.grpc.examples.helloworld.sayHelloClientStreaming
+import io.grpc.examples.helloworld.sayHelloServerStreaming
+import io.grpc.examples.helloworld.sayHelloStreaming
+import io.grpc.examples.helloworld.send
+import io.grpc.stub.StreamObserver
 import io.grpc.testing.GrpcServerRule
-import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.*
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.channels.receiveOrNull
+import kotlinx.coroutines.channels.toList
+import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-@UseExperimental(ExperimentalCoroutinesApi::class,ObsoleteCoroutinesApi::class)
 class GrpcStubExtsGeneratorTests {
 
     @[Rule JvmField]
     var grpcServerRule = GrpcServerRule().directExecutor()
-
-    val expectedMessage = "result"
 
     @BeforeTest
     fun setupService(){
@@ -44,22 +62,9 @@ class GrpcStubExtsGeneratorTests {
             override val initialContext: CoroutineContext
                 get() = Dispatchers.Unconfined
 
-            override suspend fun sayHello(request: HelloRequest): HelloReply {
-                return HelloReply { message = expectedMessage }
-            }
-
             override suspend fun sayHelloClientStreaming(requestChannel: ReceiveChannel<HelloRequest>): HelloReply {
                 return HelloReply {
                     message = requestChannel.toList().joinToString(separator = "|"){ it.name }
-                }
-            }
-
-            override suspend fun sayHelloServerStreaming(
-                request: HelloRequest,
-                responseChannel: SendChannel<HelloReply>
-            ) {
-                repeat(3){
-                    responseChannel.send { message = request.name + "-$it" }
                 }
             }
 
@@ -77,30 +82,6 @@ class GrpcStubExtsGeneratorTests {
     }
 
     @Test
-    fun `Unary blocking exts are generated`(){
-        val stub = GreeterGrpc.newBlockingStub(grpcServerRule.channel)
-        assertEquals(expectedMessage,stub.sayHello(HelloRequest.getDefaultInstance()).message)
-        assertEquals(expectedMessage,stub.sayHello().message)
-        assertEquals(expectedMessage,stub.sayHello { name = "test" }.message)
-    }
-
-    @Test
-    fun `Unary future exts are generated`(){
-        val stub = GreeterGrpc.newFutureStub(grpcServerRule.channel)
-        assertEquals(expectedMessage,stub.sayHello(HelloRequest.getDefaultInstance()).get().message)
-        assertEquals(expectedMessage,stub.sayHello().get().message)
-        assertEquals(expectedMessage,stub.sayHello { name = "test" }.get().message)
-    }
-
-    @Test
-    fun `Unary coroutine exts are generated`() = runBlocking {
-        val stub = GreeterGrpc.newStub(grpcServerRule.channel)
-        assertEquals(expectedMessage,stub.sayHello(HelloRequest.getDefaultInstance()).message)
-        assertEquals(expectedMessage,stub.sayHello().message)
-        assertEquals(expectedMessage,stub.sayHello { name = "test" }.message)
-    }
-
-    @Test
     fun `Client streaming coroutine exts are generated`() = runBlocking {
         val stub = GreeterGrpc.newStub(grpcServerRule.channel)
             .withCoroutineContext()
@@ -113,36 +94,6 @@ class GrpcStubExtsGeneratorTests {
             }
         }
         assertEquals("name 0|name 1|name 2",response.await().message)
-    }
-
-    @Test
-    fun `Server streaming coroutine exts are generated`() = runBlocking {
-        val stub = GreeterGrpc.newStub(grpcServerRule.channel)
-            .withCoroutineContext()
-
-        // Default Value Ext
-        val response1 = stub.sayHelloServerStreaming()
-        repeat(3){
-            assertEquals("-$it",response1.receive().message)
-        }
-        assertNull(response1.receiveOrNull())
-        assert(response1.isClosedForReceive)
-
-        // Single Message Parameter Ext
-        val response2 = stub.sayHelloServerStreaming(HelloRequest { name = "with-arg" })
-        repeat(3){
-            assertEquals("with-arg-$it",response2.receive().message)
-        }
-        assertNull(response2.receiveOrNull())
-        assert(response2.isClosedForReceive)
-
-        // Message Builder Ext
-        val response3 = stub.sayHelloServerStreaming { name = "with-block" }
-        repeat(3){
-            assertEquals("with-block-$it",response3.receive().message)
-        }
-        assertNull(response3.receiveOrNull())
-        assert(response3.isClosedForReceive)
     }
 
     @Test
@@ -172,4 +123,224 @@ class GrpcStubExtsGeneratorTests {
             )
         }
     }
+}
+
+class GrpcStubServerStreamingExtsGeneratorTests {
+
+    @[Rule JvmField]
+    var grpcServerRule = GrpcServerRule().directExecutor()
+
+    @BeforeTest
+    fun setupService(){
+        grpcServerRule.serviceRegistry.addService(object : GreeterCoroutineGrpc.GreeterImplBase(){
+            override val initialContext: CoroutineContext = Dispatchers.Unconfined
+            override suspend fun sayHelloServerStreaming(
+                request: HelloRequest,
+                responseChannel: SendChannel<HelloReply>
+            ) {
+                repeat(3){
+                    responseChannel.send { message = request.name + "-$it" }
+                }
+            }
+        })
+    }
+
+    @Test
+    fun `Async stub exts for default arg are generated`() {
+        val responseObserver = spyk(TestObserver())
+        val stub = GreeterGrpc.newStub(grpcServerRule.channel)
+
+        stub.sayHelloServerStreaming(responseObserver)
+        while(!responseObserver.isCompleted.get()){}
+        repeat(3){ index ->
+            verify(exactly = 1) { responseObserver.onNext(match { it.message == "-$index" }) }
+        }
+    }
+
+    @Test
+    fun `Async stub exts for lambda builders are generated`() {
+        val responseObserver = spyk(TestObserver())
+        val stub = GreeterGrpc.newStub(grpcServerRule.channel)
+
+        stub.sayHelloServerStreaming(responseObserver){ name = "test" }
+        while(!responseObserver.isCompleted.get()){}
+        repeat(3){ index ->
+            verify(exactly = 1) { responseObserver.onNext(match { it.message == "test-$index" }) }
+        }
+    }
+
+    @Test
+    fun `Async stub exts for method signatures are generated`() {
+        val responseObserver = spyk(TestObserver())
+        val stub = GreeterGrpc.newStub(grpcServerRule.channel)
+
+        stub.sayHelloServerStreaming("test", responseObserver)
+        while(!responseObserver.isCompleted.get()){}
+        repeat(3){ index ->
+            verify(exactly = 1) { responseObserver.onNext(match { it.message == "test-$index" }) }
+        }
+    }
+
+    @Test
+    fun `Blocking stub default arg exts are generated`() {
+        val stub = GreeterGrpc.newBlockingStub(grpcServerRule.channel)
+
+        val result = stub.sayHelloServerStreaming().asSequence().toList()
+        assertEquals(3, result.size)
+        result.withIndex().forEach { (index, reply) ->
+            assertEquals("-$index",reply.message)
+        }
+    }
+
+    @Test
+    fun `Blocking stub lambda builder exts are generated`() {
+        val stub = GreeterGrpc.newBlockingStub(grpcServerRule.channel)
+
+        val result = stub.sayHelloServerStreaming { name = "with-arg" }.asSequence().toList()
+        assertEquals(3, result.size)
+        result.withIndex().forEach { (index, reply) ->
+            assertEquals("with-arg-$index",reply.message)
+        }
+    }
+
+    @Test
+    fun `Blocking stub method signature exts are generated`() {
+        val stub = GreeterGrpc.newBlockingStub(grpcServerRule.channel)
+
+        val result = stub.sayHelloServerStreaming(name = "with-arg").asSequence().toList()
+        assertEquals(3, result.size)
+        result.withIndex().forEach { (index, reply) ->
+            assertEquals("with-arg-$index",reply.message)
+        }
+    }
+
+    @Test
+    fun `Async stub coroutine exts are generated`() = runBlocking {
+        val stub = GreeterGrpc.newStub(grpcServerRule.channel)
+            .withCoroutineContext()
+
+        // Default Value Ext
+        val response1 = stub.sayHelloServerStreaming()
+        repeat(3){
+            assertEquals("-$it",response1.receive().message)
+        }
+        assertNull(response1.receiveOrNull())
+        assert(response1.isClosedForReceive)
+
+        // Single Message Parameter Ext
+        val response2 = stub.sayHelloServerStreaming(HelloRequest { name = "with-arg" })
+        repeat(3){
+            assertEquals("with-arg-$it",response2.receive().message)
+        }
+        assertNull(response2.receiveOrNull())
+        assert(response2.isClosedForReceive)
+    }
+
+    @Test
+    fun `Async stub coroutine lambda builder exts are generated`() = runBlocking {
+        val stub = GreeterGrpc.newStub(grpcServerRule.channel)
+            .withCoroutineContext()
+
+        // Message Builder Ext
+        val response = stub.sayHelloServerStreaming { name = "with-block" }
+        repeat(3){
+            assertEquals("with-block-$it",response.receive().message)
+        }
+        assertNull(response.receiveOrNull())
+        assert(response.isClosedForReceive)
+    }
+
+    @Test
+    fun `Async stub coroutine method signature exts are generated`() = runBlocking {
+        val stub = GreeterGrpc.newStub(grpcServerRule.channel)
+            .withCoroutineContext()
+
+        // Method signature Ext
+        val response = stub.sayHelloServerStreaming(name = "with-block")
+        repeat(3){
+            assertEquals("with-block-$it",response.receive().message)
+        }
+        assertNull(response.receiveOrNull())
+        assert(response.isClosedForReceive)
+    }
+}
+
+class GrpcStubUnaryExtsGeneratorTests {
+
+    @[Rule JvmField]
+    var grpcServerRule = GrpcServerRule().directExecutor()
+
+    @BeforeTest
+    fun setupService(){
+        grpcServerRule.serviceRegistry.addService(object : GreeterCoroutineGrpc.GreeterImplBase(){
+            override val initialContext: CoroutineContext = Dispatchers.Unconfined
+            override suspend fun sayHello(request: HelloRequest): HelloReply {
+                return HelloReply { message = "result-${request.name}" }
+            }
+        })
+    }
+
+    @Test
+    fun `Async stub exts for default arg are generated`() {
+        val responseObserver = spyk(TestObserver())
+        val stub = GreeterGrpc.newStub(grpcServerRule.channel)
+
+        stub.sayHello(responseObserver)
+        while(!responseObserver.isCompleted.get()){}
+        verify(exactly = 1) { responseObserver.onNext(match { it.message == "result-" }) }
+    }
+
+    @Test
+    fun `Async stub exts for lambda builders are generated`() {
+        val responseObserver = spyk(TestObserver())
+        val stub = GreeterGrpc.newStub(grpcServerRule.channel)
+
+        stub.sayHello(responseObserver){ name = "test" }
+        while(!responseObserver.isCompleted.get()){}
+        verify(exactly = 1) { responseObserver.onNext(match { it.message == "result-test" }) }
+    }
+
+    @Test
+    fun `Async stub exts for method signatures are generated`() {
+        val responseObserver = spyk(TestObserver())
+        val stub = GreeterGrpc.newStub(grpcServerRule.channel)
+
+        stub.sayHello("test", responseObserver)
+        while(!responseObserver.isCompleted.get()){}
+        verify(exactly = 1) { responseObserver.onNext(match { it.message == "result-test" }) }
+    }
+
+    @Test
+    fun `Blocking stub exts are generated`(){
+        val stub = GreeterGrpc.newBlockingStub(grpcServerRule.channel)
+        assertEquals("result-",stub.sayHello(HelloRequest.getDefaultInstance()).message)
+        assertEquals("result-",stub.sayHello().message)
+        assertEquals("result-test",stub.sayHello { name = "test" }.message)
+        assertEquals("result-test",stub.sayHello(name = "test").message)
+    }
+
+    @Test
+    fun `Future stub exts are generated`(){
+        val stub = GreeterGrpc.newFutureStub(grpcServerRule.channel)
+        assertEquals("result-",stub.sayHello(HelloRequest.getDefaultInstance()).get().message)
+        assertEquals("result-",stub.sayHello().get().message)
+        assertEquals("result-test",stub.sayHello { name = "test" }.get().message)
+        assertEquals("result-test",stub.sayHello(name = "test").get().message)
+    }
+
+    @Test
+    fun `Async stub coroutine exts are generated`() = runBlocking {
+        val stub = GreeterGrpc.newStub(grpcServerRule.channel)
+        assertEquals("result-",stub.sayHello(HelloRequest.getDefaultInstance()).message)
+        assertEquals("result-",stub.sayHello().message)
+        assertEquals("result-test",stub.sayHello { name = "test" }.message)
+        assertEquals("result-test",stub.sayHello(name = "test").message)
+    }
+}
+
+class TestObserver : StreamObserver<HelloReply> {
+    val isCompleted = AtomicBoolean()
+    override fun onNext(value: HelloReply?) {}
+    override fun onError(t: Throwable?) { isCompleted.set(true) }
+    override fun onCompleted() { isCompleted.set(true) }
 }

--- a/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcStubExtsGeneratorTests.kt
+++ b/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcStubExtsGeneratorTests.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:UseExperimental(ExperimentalCoroutinesApi::class,ObsoleteCoroutinesApi::class)
-
 package com.github.marcoferrer.krotoplus.generators
 
 import com.github.marcoferrer.krotoplus.coroutines.launchProducerJob
@@ -50,6 +48,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
+@UseExperimental(ExperimentalCoroutinesApi::class)
 class GrpcStubExtsGeneratorTests {
 
     @[Rule JvmField]
@@ -125,6 +124,7 @@ class GrpcStubExtsGeneratorTests {
     }
 }
 
+@UseExperimental(ExperimentalCoroutinesApi::class)
 class GrpcStubServerStreamingExtsGeneratorTests {
 
     @[Rule JvmField]

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/Generator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/Generator.kt
@@ -88,5 +88,12 @@ fun initializeContext(compilerConfig: CompilerConfig? = null) {
 
 
 private val OptionsExtRegistry = ExtensionRegistry.newInstance().also {
+    // Register extensions for reading method signature options
     ClientProto.registerAllExtensions(it)
+
+    // Register extensions used for ready http options.
+    // Currently there isnt a generator that leverages this option
+    // but there are existing community scripts that would benefit
+    // from this.
+    AnnotationsProto.registerAllExtensions(it)
 }

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcCoroutinesGenerator.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/generators/GrpcCoroutinesGenerator.kt
@@ -598,7 +598,7 @@ object GrpcCoroutinesGenerator : Generator {
             .addModifiers(KModifier.SUSPEND)
             .returns(responseClassName)
             .addForEach(methodSignatureFields){
-                addParameter(upperCamelCase(it.name).decapitalize(), it.getFieldClassName(context.schema))
+                addParameter(it.name.toUpperCamelCase().decapitalize(), it.getFieldClassName(context.schema))
             }
             .addCode(requestClassName.requestValueMethodSigCodeBlock(methodSignatureFields))
             .addStatement("return %N(request)",functionName)
@@ -618,7 +618,7 @@ object GrpcCoroutinesGenerator : Generator {
             null else FunSpec.builder(functionName)
             .returns(CommonClassNames.receiveChannel.parameterizedBy(responseClassName))
             .addForEach(methodSignatureFields){
-                addParameter(upperCamelCase(it.name).decapitalize(), it.getFieldClassName(context.schema))
+                addParameter(it.name.toUpperCamelCase().decapitalize(), it.getFieldClassName(context.schema))
             }
             .addCode(requestClassName.requestValueMethodSigCodeBlock(methodSignatureFields))
             .addStatement("return %N(request)",functionName)

--- a/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/utils/CoroutineStubExts.kt
+++ b/protoc-gen-kroto-plus/src/main/kotlin/com/github/marcoferrer/krotoplus/utils/CoroutineStubExts.kt
@@ -26,7 +26,13 @@ val ClassName.requestParamSpec: ParameterSpec
         .build()
 
 val ClassName.requestValueBuilderCodeBlock: CodeBlock
-    inline get() = CodeBlock.of("val request = %T.newBuilder().apply(block).build()\n", this)
+    inline get() = CodeBlock.builder()
+        .addStatement("val request = %T.newBuilder()", this)
+        .indent()
+        .addStatement(".apply(block)")
+        .addStatement(".build()")
+        .unindent()
+        .build()
 
 fun ClassName.requestValueMethodSigCodeBlock(fields: List<DescriptorProtos.FieldDescriptorProto>): CodeBlock {
 

--- a/test-api/src/main/proto/helloworld.proto
+++ b/test-api/src/main/proto/helloworld.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "google/api/client.proto";
+
 option java_multiple_files = true;
 option java_package = "io.grpc.examples.helloworld";
 option java_outer_classname = "HelloWorldProto";
@@ -11,14 +13,18 @@ package helloworld;
 service Greeter {
 
     // Sends a greeting
-    rpc SayHello (HelloRequest) returns (HelloReply);
+    rpc SayHello (HelloRequest) returns (HelloReply){
+        option (google.api.method_signature) = "name";
+    };
 
     // Streams a many greetings
     rpc SayHelloStreaming (stream HelloRequest) returns (stream HelloReply);
 
     rpc SayHelloClientStreaming (stream HelloRequest) returns (HelloReply);
 
-    rpc SayHelloServerStreaming (HelloRequest) returns (stream HelloReply);
+    rpc SayHelloServerStreaming (HelloRequest) returns (stream HelloReply){
+        option (google.api.method_signature) = "name";
+    };
 }
 
 // The request message containing the user's name.


### PR DESCRIPTION
This PR refactors the implementation of the grpc stub extension generator. It also adds support for generating stub extensions based on method signature annotations.