### PR TITLE
Build native executable artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ subprojects{ subproject ->
         testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
     }
 
-
     tasks.withType(Test) {
         testLogging {
             // set options for log level LIFECYCLE
@@ -95,6 +94,27 @@ subprojects{ subproject ->
                     def startItem = '|  ', endItem = '  |'
                     def repeatLength = startItem.length() + output.length() + endItem.length()
                     println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+                }
+            }
+        }
+    }
+
+    subproject.ext{
+        localPluginPath = [
+                "kroto": "${rootProject.projectDir}/protoc-gen-kroto-plus/build/libs/protoc-gen-kroto-plus-${project.version}-${osdetector.classifier}.exe",
+                "coroutines": "${rootProject.projectDir}/protoc-gen-grpc-coroutines/build/libs/protoc-gen-grpc-coroutines-${project.version}-${osdetector.classifier}.exe"
+        ]
+
+        configProtoTaskWithKroto = { task, krotoConfig ->
+            task.inputs.files krotoConfig
+            task.dependsOn ':protoc-gen-kroto-plus:buildCanteenArtifacts'
+            task.plugins {
+                kroto {
+                    outputSubDir = "java"
+                    // We want to relativize the configuration path
+                    // because absolute paths cause issues in windows
+                    // environments
+                    option "ConfigPath=${krotoConfig.absolutePath.replace(rootProject.projectDir.path, "").drop(1)}"
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ subprojects{ subproject ->
     apply plugin: 'kotlin'
 
     group = 'com.github.marcoferrer.krotoplus'
-    version = '0.5.0'
+    version = '0.6.0-SNAPSHOT'
 
     compileKotlin {
         kotlinOptions.jvmTarget = "1.8"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,4 +4,8 @@ plugins {
 repositories {
     jcenter()
 }
-        
+
+dependencies {
+    // Needed by the script 'canteen.gradle'
+    implementation("com.google.guava:guava:27.0.1-jre")
+}

--- a/canteen.gradle
+++ b/canteen.gradle
@@ -1,0 +1,81 @@
+// The following dependency needs to exist on the 'buildscript' classpath
+// 'com.google.guava:guava:27.0.1-jre'
+// It is currently added via the buildSrc project
+import com.google.common.io.ByteStreams
+
+// Native artifact generation based off of
+// https://github.com/salesforce/grpc-java-contrib/tree/master/canteen
+
+def platforms = ["osx-x86_64", "linux-x86_64", "windows-x86_64"]
+
+Task bootJarTask = tasks.getByName("bootJar")
+File bootJarFile = bootJarTask.archiveFile.get().asFile
+
+platforms.each { platform ->
+
+    // Resolve the canteen bootstrap artifact
+    Configuration config = project.configurations.create("canteenBootstrapLocator_$platform") {
+        visible = false
+        transitive = false
+        extendsFrom = []
+    }
+    Map<String, String> notation = [
+            group: "com.salesforce.servicelibs",
+            name: "canteen-bootstrap",
+            version: "1.0.0",
+            classifier: platform,
+            ext: "exe",
+    ]
+    Dependency dep = project.dependencies.add(config.name, notation)
+    File bootstrapFile = config.fileCollection(dep).singleFile
+    File destinationArtifactFile = new File(bootJarTask.destinationDirectory.get().asFile,
+            bootJarFile.name.replace("jvm8.jar", platform + ".exe"))
+
+    // Create task to copy the original jar and embed the
+    // canteen bootstrap executable for the target platform
+    Task canteenTask = task("canteenArtifact_$platform"){
+        group = "canteen"
+        dependsOn("bootJar")
+        // Add files for UP-TO-DATE checks
+        inputs.files(bootJarFile)
+        outputs.files(destinationArtifactFile)
+        doLast {
+            // Build the bootstrap file
+            OutputStream targetStream = new FileOutputStream(destinationArtifactFile)
+            InputStream bootstrapStream = new FileInputStream(bootstrapFile)
+            ByteStreams.copy(bootstrapStream, targetStream);
+            InputStream sourceStream = new FileInputStream(bootJarFile)
+            ByteStreams.copy(sourceStream, targetStream);
+            targetStream.flush()
+            targetStream.close()
+            sourceStream.close()
+            bootstrapStream.close()
+            destinationArtifactFile.setExecutable(true);
+        }
+    }
+
+    artifacts {
+        archives(destinationArtifactFile) {
+            builtBy canteenTask
+            classifier platform
+        }
+    }
+
+    publishing {
+        publications {
+            mavenPublication(MavenPublication) {
+                artifact(destinationArtifactFile.absolutePath) {
+                    builtBy canteenTask
+                    classifier platform
+                }
+            }
+        }
+    }
+}
+
+task buildCanteenArtifacts{
+    group = "canteen"
+    platforms.each { platform ->
+        dependsOn("canteenArtifact_$platform")
+    }
+}

--- a/example-project/build.gradle
+++ b/example-project/build.gradle
@@ -89,7 +89,7 @@ protobuf {
     plugins {
         grpc { artifact = "io.grpc:protoc-gen-grpc-java:${versions.grpc}" }
         kroto {
-            artifact = "com.github.marcoferrer.krotoplus:protoc-gen-kroto-plus:${versions.krotoplus}:jvm8@jar"
+            path = "${rootDir}/../protoc-gen-kroto-plus/build/libs/protoc-gen-kroto-plus-${versions.krotoplus}-${osdetector.classifier}.exe"
         }
     }
 

--- a/example-project/build.gradle
+++ b/example-project/build.gradle
@@ -5,7 +5,7 @@ buildscript {
                 "grpc":       '1.23.0',
                 "kotlin":     '1.3.50',
                 "coroutines": '1.3.0',
-                "krotoplus":  '0.5.0'
+                "krotoplus":  '0.6.0-SNAPSHOT'
         ]
     }
 
@@ -89,7 +89,7 @@ protobuf {
     plugins {
         grpc { artifact = "io.grpc:protoc-gen-grpc-java:${versions.grpc}" }
         kroto {
-            path = "${rootDir}/../protoc-gen-kroto-plus/build/libs/protoc-gen-kroto-plus-${versions.krotoplus}-${osdetector.classifier}.exe"
+            artifact = "com.github.marcoferrer.krotoplus:protoc-gen-kroto-plus:${versions.krotoplus}"
         }
     }
 

--- a/kroto-plus-coroutines/benchmark/build.gradle
+++ b/kroto-plus-coroutines/benchmark/build.gradle
@@ -37,7 +37,7 @@ protobuf {
     //noinspection GroovyAssignabilityCheck
     plugins {
         kroto {
-            path = "${rootProject.projectDir}/protoc-gen-kroto-plus/build/libs/protoc-gen-kroto-plus-${project.version}-jvm8.jar"
+            path = localPluginPath.kroto
         }
     }
 
@@ -45,16 +45,9 @@ protobuf {
         def krotoConfig = file("krotoPlusConfig.asciipb")
 
         all().each{ task ->
-            task.inputs.files krotoConfig
-            task.dependsOn ':protoc-gen-kroto-plus:bootJar'
-
+            configProtoTaskWithKroto(task, krotoConfig)
             task.builtins {
                 remove java
-            }
-            task.plugins {
-                kroto {
-                    option "ConfigPath=$krotoConfig"
-                }
             }
         }
     }

--- a/kroto-plus-coroutines/build.gradle
+++ b/kroto-plus-coroutines/build.gradle
@@ -63,14 +63,13 @@ protobuf {
     //noinspection GroovyAssignabilityCheck
     plugins {
         coroutines {
-            path = "${rootProject.projectDir}/protoc-gen-grpc-coroutines/build/libs/protoc-gen-grpc-coroutines-${project.version}-jvm8.jar"
+            path = "${rootProject.projectDir}/protoc-gen-grpc-coroutines/build/libs/protoc-gen-grpc-coroutines-${project.version}-${osdetector.classifier}.exe"
         }
     }
 
     generateProtoTasks {
-
         all().each{ task ->
-            task.dependsOn ':protoc-gen-grpc-coroutines:bootJar'
+            task.dependsOn ':protoc-gen-grpc-coroutines:buildCanteenArtifacts'
             task.builtins {
                 remove java
             }

--- a/kroto-plus-coroutines/build.gradle
+++ b/kroto-plus-coroutines/build.gradle
@@ -63,7 +63,7 @@ protobuf {
     //noinspection GroovyAssignabilityCheck
     plugins {
         coroutines {
-            path = "${rootProject.projectDir}/protoc-gen-grpc-coroutines/build/libs/protoc-gen-grpc-coroutines-${project.version}-${osdetector.classifier}.exe"
+            path = localPluginPath.coroutines
         }
     }
 

--- a/kroto-plus-gradle-plugin/build.gradle
+++ b/kroto-plus-gradle-plugin/build.gradle
@@ -43,20 +43,19 @@ protobuf {
     //noinspection GroovyAssignabilityCheck
     plugins {
         kroto {
-            artifact = "com.github.marcoferrer.krotoplus:protoc-gen-kroto-plus:0.1.3:jvm8@jar"
+            path = localPluginPath.kroto
         }
     }
 
     generateProtoTasks {
         def krotoConfig = file("krotoPlusConfig.asciipb")
 
-        all().each{ task ->
+        all().each { task ->
             task.inputs.files krotoConfig
-            task.dependsOn ':kroto-plus-gradle-plugin:gen-config-dsl:jar'
+            task.dependsOn ':protoc-gen-kroto-plus:buildCanteenArtifacts'
             task.plugins {
                 kroto {
                     outputSubDir = "java"
-                    option "ConfigPath=$krotoConfig"
                 }
             }
         }

--- a/protoc-gen-grpc-coroutines/build.gradle
+++ b/protoc-gen-grpc-coroutines/build.gradle
@@ -31,6 +31,8 @@ bootJar {
     }
 }
 
+apply from: "${rootProject.projectDir}/canteen.gradle"
+
 jar.enabled = true
 
 artifacts {

--- a/protoc-gen-kroto-plus/build.gradle
+++ b/protoc-gen-kroto-plus/build.gradle
@@ -83,6 +83,8 @@ bootJar {
     }
 }
 
+apply from: "${rootProject.projectDir}/canteen.gradle"
+
 jar.enabled = true
 
 artifacts {

--- a/protoc-gen-kroto-plus/generator-tests/build.gradle
+++ b/protoc-gen-kroto-plus/generator-tests/build.gradle
@@ -42,7 +42,7 @@ protobuf {
     //noinspection GroovyAssignabilityCheck
     plugins {
         kroto {
-            path = "${rootProject.projectDir}/protoc-gen-kroto-plus/build/libs/protoc-gen-kroto-plus-${project.version}-${osdetector.classifier}.exe"
+            path = localPluginPath.kroto
         }
     }
 
@@ -50,15 +50,7 @@ protobuf {
         def krotoConfig = file("krotoPlusConfig.asciipb")
 
         all().each{ task ->
-            task.inputs.files krotoConfig
-            task.dependsOn ':protoc-gen-kroto-plus:buildCanteenArtifacts'
-
-            task.plugins {
-                kroto {
-                    outputSubDir = "java"
-                    option "ConfigPath=$krotoConfig"
-                }
-            }
+            configProtoTaskWithKroto(task, krotoConfig)
         }
     }
 }

--- a/protoc-gen-kroto-plus/generator-tests/build.gradle
+++ b/protoc-gen-kroto-plus/generator-tests/build.gradle
@@ -42,7 +42,7 @@ protobuf {
     //noinspection GroovyAssignabilityCheck
     plugins {
         kroto {
-            path = "${rootProject.projectDir}/protoc-gen-kroto-plus/build/libs/protoc-gen-kroto-plus-${project.version}-jvm8.jar"
+            path = "${rootProject.projectDir}/protoc-gen-kroto-plus/build/libs/protoc-gen-kroto-plus-${project.version}-${osdetector.classifier}.exe"
         }
     }
 
@@ -51,7 +51,7 @@ protobuf {
 
         all().each{ task ->
             task.inputs.files krotoConfig
-            task.dependsOn ':protoc-gen-kroto-plus:bootJar'
+            task.dependsOn ':protoc-gen-kroto-plus:buildCanteenArtifacts'
 
             task.plugins {
                 kroto {


### PR DESCRIPTION
This PR should resolve the existing issues around executing the protoc plugins on windows.
It will allow each of the kroto plugins to behave as a native platform executable.  The strategy used is an adaptation of the work being done in [salesforce/grpc-java-contrib/canteen](https://github.com/salesforce/grpc-java-contrib/tree/master/canteen)

This will also simplify artifact configuration in the protobuf gradle plugin.

Issue #83 should be fully resolved by this.
Issue #6 will be partially resolved.