### PR TITLE
Prevent class name collisions in proto builders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,25 +33,32 @@ subprojects{ subproject ->
     }
 
     apply plugin: 'idea'
-    apply plugin: 'kotlin'
 
     group = 'com.github.marcoferrer.krotoplus'
     version = '0.6.0-SNAPSHOT'
 
-    compileKotlin {
-        kotlinOptions.jvmTarget = "1.8"
-    }
+    if(!subproject.path.contains("test-api")){
+        apply plugin: 'kotlin'
 
-    compileTestKotlin {
-        kotlinOptions.jvmTarget = "1.8"
+        compileKotlin {
+            kotlinOptions.jvmTarget = "1.8"
+        }
+
+        compileTestKotlin {
+            kotlinOptions.jvmTarget = "1.8"
+        }
+
+        dependencies {
+            implementation "org.jetbrains.kotlin:kotlin-stdlib"
+            testImplementation "org.jetbrains.kotlin:kotlin-test"
+            testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
+        }
+    }else{
+        apply plugin: 'java'
     }
 
     dependencies {
-        implementation "org.jetbrains.kotlin:kotlin-stdlib"
-
         testImplementation group: 'junit', name: 'junit', version: '[4,)'
-        testImplementation "org.jetbrains.kotlin:kotlin-test"
-        testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
     }
 
     tasks.withType(Test) {
@@ -111,10 +118,14 @@ subprojects{ subproject ->
             task.plugins {
                 kroto {
                     outputSubDir = "java"
-                    // We want to relativize the configuration path
-                    // because absolute paths cause issues in windows
-                    // environments
-                    option "ConfigPath=${krotoConfig.absolutePath.replace(rootProject.projectDir.path, "").drop(1)}"
+                    if(osdetector.os == "windows") {
+                        // We want to relativize the configuration path
+                        // because absolute paths cause issues in windows
+                        // environments
+                        option "ConfigPath=${krotoConfig.absolutePath.replace(System.getProperty("user.dir"), "").drop(1)}"
+                    } else {
+                        option "ConfigPath=$krotoConfig"
+                    }
                 }
             }
         }

--- a/docs/html/kroto-plus-config.html
+++ b/docs/html/kroto-plus-config.html
@@ -183,7 +183,7 @@
                 </li>
               
                 <li>
-                  <a href="#krotoplus.compiler.ExtenableMessagesGenOptions"><span class="badge">M</span>ExtenableMessagesGenOptions</a>
+                  <a href="#krotoplus.compiler.ExtendableMessagesGenOptions"><span class="badge">M</span>ExtendableMessagesGenOptions</a>
                 </li>
               
                 <li>
@@ -273,7 +273,7 @@
               
                 <tr>
                   <td>extendable_messages</td>
-                  <td><a href="#krotoplus.compiler.ExtenableMessagesGenOptions">ExtenableMessagesGenOptions</a></td>
+                  <td><a href="#krotoplus.compiler.ExtendableMessagesGenOptions">ExtendableMessagesGenOptions</a></td>
                   <td>repeated</td>
                   <td><p>Configuration entries for the &#39;Extendable Messages&#39; code generator. </p></td>
                 </tr>
@@ -301,11 +301,12 @@
               
             </tbody>
           </table>
-        
+
+          
 
         
       
-        <h3 id="krotoplus.compiler.ExtenableMessagesGenOptions">ExtenableMessagesGenOptions</h3>
+        <h3 id="krotoplus.compiler.ExtendableMessagesGenOptions">ExtendableMessagesGenOptions</h3>
         <p>Configuration used by the 'Extendable Messages' code generator.</p><p>Since this code generator relies on the protoc insertion point API,</p><p>its outputDir must match that of the protoc java plugin.</p>
 
         
@@ -360,7 +361,8 @@ ie. com.krotoplus.example.MyCompanionInterface&lt;{{message_type}}, {{message_ty
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -397,7 +399,8 @@ ie. google/* </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -442,7 +445,8 @@ ie. &#39;sampleInsertionScript.kts&#39; </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -466,7 +470,8 @@ The default filter will match true against all input files. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -498,7 +503,8 @@ This options generates code that relies on the artifact &#39;kroto-plus-coroutin
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -529,7 +535,8 @@ The default filter will match true against all input files. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -582,7 +589,8 @@ ie. &#39;sampleInsertionScript.kts&#39; </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -636,7 +644,8 @@ Useful when registering mock services to a GrpcServerRule during unit tests. </p
               
             </tbody>
           </table>
-        
+
+          
 
         
       
@@ -663,10 +672,11 @@ The default filter will match true against all input files. </p></td>
                   <td><a href="#bool">bool</a></td>
                   <td></td>
                   <td><p>By default the generated utility methods for building messages are
-wrapped in an object similiar to a proto outer class. For better
-ergonomics with code generated using &#39;java_multiple_files&#39; the
+wrapped in an object similar to a proto outer class. For better
+ergonomics with code generated using &#39;java_multiple_files = false&#39; the
 builders can be unwrapped and generated at the root scope of
-the output file. </p></td>
+the output file. This option is *not* compatible with  &#39;java_multiple_files = true&#39;
+and nested messages since the generated code would produce class name collisions </p></td>
                 </tr>
               
                 <tr>
@@ -681,7 +691,8 @@ provides safer and predictable dsl usage. </p></td>
               
             </tbody>
           </table>
-        
+
+          
 
         
       

--- a/docs/markdown/kroto-plus-config.md
+++ b/docs/markdown/kroto-plus-config.md
@@ -5,7 +5,7 @@
 
 - [krotoplus/compiler/config.proto](#krotoplus/compiler/config.proto)
     - [CompilerConfig](#krotoplus.compiler.CompilerConfig)
-    - [ExtenableMessagesGenOptions](#krotoplus.compiler.ExtenableMessagesGenOptions)
+    - [ExtendableMessagesGenOptions](#krotoplus.compiler.ExtendableMessagesGenOptions)
     - [FileFilter](#krotoplus.compiler.FileFilter)
     - [GeneratorScriptsGenOptions](#krotoplus.compiler.GeneratorScriptsGenOptions)
     - [GrpcCoroutinesGenOptions](#krotoplus.compiler.GrpcCoroutinesGenOptions)
@@ -42,7 +42,7 @@ Message backing the root of a Kroto&#43; configuration file.
 | grpc_stub_exts | [GrpcStubExtsGenOptions](#krotoplus.compiler.GrpcStubExtsGenOptions) | repeated | Configuration entries for the &#39;gRPC Stub Extensions&#39; code generator. |
 | mock_services | [MockServicesGenOptions](#krotoplus.compiler.MockServicesGenOptions) | repeated | Configuration entries for the &#39;Mock Service&#39; code generator. |
 | proto_builders | [ProtoBuildersGenOptions](#krotoplus.compiler.ProtoBuildersGenOptions) | repeated | Configuration entries for the &#39;Proto Builders&#39; code generator. |
-| extendable_messages | [ExtenableMessagesGenOptions](#krotoplus.compiler.ExtenableMessagesGenOptions) | repeated | Configuration entries for the &#39;Extendable Messages&#39; code generator. |
+| extendable_messages | [ExtendableMessagesGenOptions](#krotoplus.compiler.ExtendableMessagesGenOptions) | repeated | Configuration entries for the &#39;Extendable Messages&#39; code generator. |
 | insertions | [InsertionsGenOptions](#krotoplus.compiler.InsertionsGenOptions) | repeated | Configuration entries for the &#39;Protoc Insertions&#39; code generator. |
 | generator_scripts | [GeneratorScriptsGenOptions](#krotoplus.compiler.GeneratorScriptsGenOptions) | repeated | Configuration entries for the &#39;Generator Scripts&#39; code generator. |
 | grpc_coroutines | [GrpcCoroutinesGenOptions](#krotoplus.compiler.GrpcCoroutinesGenOptions) | repeated | Configuration entries for the &#39;Grpc Coroutines&#39; code generator. |
@@ -52,9 +52,9 @@ Message backing the root of a Kroto&#43; configuration file.
 
 
 
-<a name="krotoplus.compiler.ExtenableMessagesGenOptions"></a>
+<a name="krotoplus.compiler.ExtendableMessagesGenOptions"></a>
 
-### ExtenableMessagesGenOptions
+### ExtendableMessagesGenOptions
 Configuration used by the &#39;Extendable Messages&#39; code generator.
 Since this code generator relies on the protoc insertion point API,
 its outputDir must match that of the protoc java plugin.
@@ -204,7 +204,7 @@ Configuration used by the &#39;Proto Builders&#39; code generator.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | filter | [FileFilter](#krotoplus.compiler.FileFilter) |  | Filter used for limiting the input files that are processed by the code generator The default filter will match true against all input files. |
-| unwrap_builders | [bool](#bool) |  | By default the generated utility methods for building messages are wrapped in an object similiar to a proto outer class. For better ergonomics with code generated using &#39;java_multiple_files&#39; the builders can be unwrapped and generated at the root scope of the output file. |
+| unwrap_builders | [bool](#bool) |  | By default the generated utility methods for building messages are wrapped in an object similar to a proto outer class. For better ergonomics with code generated using &#39;java_multiple_files = false&#39; the builders can be unwrapped and generated at the root scope of the output file. This option is *not* compatible with &#39;java_multiple_files = true&#39; and nested messages since the generated code would produce class name collisions |
 | use_dsl_markers | [bool](#bool) |  | Tag java builder classes with a kotlin interface annotated with @DslMarker. This requires the kroto-plus output directory to match the generated java classes directory. Using @DslMarker provides safer and predictable dsl usage. |
 
 

--- a/protoc-gen-kroto-plus/generator-tests/build.gradle
+++ b/protoc-gen-kroto-plus/generator-tests/build.gradle
@@ -21,7 +21,9 @@ dependencies{
     testImplementation "io.grpc:grpc-stub:${Versions.grpc}"
     testImplementation "io.grpc:grpc-netty:${Versions.grpc}"
     testImplementation "io.grpc:grpc-testing:${Versions.grpc}"
-    
+
+    testProtobuf "com.google.api.grpc:proto-google-common-protos:${Versions.commonProto}"
+
     testProtobuf project(':test-api')
     testImplementation project(':test-api:grpc')
     testImplementation project(':kroto-plus-message')

--- a/protoc-gen-kroto-plus/generator-tests/build.gradle
+++ b/protoc-gen-kroto-plus/generator-tests/build.gradle
@@ -22,8 +22,6 @@ dependencies{
     testImplementation "io.grpc:grpc-netty:${Versions.grpc}"
     testImplementation "io.grpc:grpc-testing:${Versions.grpc}"
 
-    testProtobuf "com.google.api.grpc:proto-google-common-protos:${Versions.commonProto}"
-
     testProtobuf project(':test-api')
     testImplementation project(':test-api:grpc')
     testImplementation project(':kroto-plus-message')

--- a/protoc-gen-kroto-plus/generator-tests/krotoPlusConfig.asciipb
+++ b/protoc-gen-kroto-plus/generator-tests/krotoPlusConfig.asciipb
@@ -6,6 +6,11 @@ proto_builders {
     unwrap_builders: true
     use_dsl_markers: true
 }
+proto_builders {
+    filter { include_path: "google/rpc/*" }
+    unwrap_builders: true
+    use_dsl_markers: true
+}
 grpc_stub_exts {
     support_coroutines: true
 }

--- a/protoc-gen-kroto-plus/generator-tests/krotoPlusConfig.asciipb
+++ b/protoc-gen-kroto-plus/generator-tests/krotoPlusConfig.asciipb
@@ -6,11 +6,6 @@ proto_builders {
     unwrap_builders: true
     use_dsl_markers: true
 }
-proto_builders {
-    filter { include_path: "google/rpc/*" }
-    unwrap_builders: true
-    use_dsl_markers: true
-}
 grpc_stub_exts {
     support_coroutines: true
 }

--- a/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/ProtoBuildersGeneratorTests.kt
+++ b/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/ProtoBuildersGeneratorTests.kt
@@ -16,7 +16,6 @@
 
 package com.github.marcoferrer.krotoplus.generators
 
-import com.google.rpc.ErrorDetailsProtoBuilders
 import io.grpc.examples.helloworld.HelloReply
 import io.grpc.examples.helloworld.HelloRequest
 import io.grpc.examples.helloworld.HelloWorldProtoDslBuilder
@@ -119,10 +118,8 @@ class ProtoBuildersGeneratorTests {
 
     @Test
     fun `Test class name collisions are avoided`(){
-        ErrorDetailsProtoBuilders.BadRequest {  }
-        ErrorDetailsProtoBuilders.BadRequest.FieldViolation {  }
-        ErrorDetailsProtoBuilders.PreconditionFailure {  }
-        ErrorDetailsProtoBuilders.PreconditionFailure.Violation {  }
+        ClassNameCollisionProtoBuilders.CollisionMessage {  }
+        ClassNameCollisionProtoBuilders.CollisionSiblingMessage {  }
     }
 
     @Test

--- a/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/ProtoBuildersGeneratorTests.kt
+++ b/protoc-gen-kroto-plus/generator-tests/src/test/kotlin/com/github/marcoferrer/krotoplus/generators/ProtoBuildersGeneratorTests.kt
@@ -16,6 +16,7 @@
 
 package com.github.marcoferrer.krotoplus.generators
 
+import com.google.rpc.ErrorDetailsProtoBuilders
 import io.grpc.examples.helloworld.HelloReply
 import io.grpc.examples.helloworld.HelloRequest
 import io.grpc.examples.helloworld.HelloWorldProtoDslBuilder
@@ -114,6 +115,14 @@ class ProtoBuildersGeneratorTests {
         }
 
         assertEquals(message.theFieldMap[key], value)
+    }
+
+    @Test
+    fun `Test class name collisions are avoided`(){
+        ErrorDetailsProtoBuilders.BadRequest {  }
+        ErrorDetailsProtoBuilders.BadRequest.FieldViolation {  }
+        ErrorDetailsProtoBuilders.PreconditionFailure {  }
+        ErrorDetailsProtoBuilders.PreconditionFailure.Violation {  }
     }
 
     @Test

--- a/protoc-gen-kroto-plus/src/main/generated/com/github/marcoferrer/krotoplus/config/ProtoBuildersGenOptions.java
+++ b/protoc-gen-kroto-plus/src/main/generated/com/github/marcoferrer/krotoplus/config/ProtoBuildersGenOptions.java
@@ -148,10 +148,11 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * By default the generated utility methods for building messages are
-   * wrapped in an object similiar to a proto outer class. For better
-   * ergonomics with code generated using 'java_multiple_files' the
+   * wrapped in an object similar to a proto outer class. For better
+   * ergonomics with code generated using 'java_multiple_files = false' the
    * builders can be unwrapped and generated at the root scope of
-   * the output file.
+   * the output file. This option is *not* compatible with  'java_multiple_files = true'
+   * and nested messages since the generated code would produce class name collisions
    * </pre>
    *
    * <code>bool unwrap_builders = 2;</code>
@@ -697,10 +698,11 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * By default the generated utility methods for building messages are
-     * wrapped in an object similiar to a proto outer class. For better
-     * ergonomics with code generated using 'java_multiple_files' the
+     * wrapped in an object similar to a proto outer class. For better
+     * ergonomics with code generated using 'java_multiple_files = false' the
      * builders can be unwrapped and generated at the root scope of
-     * the output file.
+     * the output file. This option is *not* compatible with  'java_multiple_files = true'
+     * and nested messages since the generated code would produce class name collisions
      * </pre>
      *
      * <code>bool unwrap_builders = 2;</code>
@@ -711,10 +713,11 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * By default the generated utility methods for building messages are
-     * wrapped in an object similiar to a proto outer class. For better
-     * ergonomics with code generated using 'java_multiple_files' the
+     * wrapped in an object similar to a proto outer class. For better
+     * ergonomics with code generated using 'java_multiple_files = false' the
      * builders can be unwrapped and generated at the root scope of
-     * the output file.
+     * the output file. This option is *not* compatible with  'java_multiple_files = true'
+     * and nested messages since the generated code would produce class name collisions
      * </pre>
      *
      * <code>bool unwrap_builders = 2;</code>
@@ -728,10 +731,11 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * By default the generated utility methods for building messages are
-     * wrapped in an object similiar to a proto outer class. For better
-     * ergonomics with code generated using 'java_multiple_files' the
+     * wrapped in an object similar to a proto outer class. For better
+     * ergonomics with code generated using 'java_multiple_files = false' the
      * builders can be unwrapped and generated at the root scope of
-     * the output file.
+     * the output file. This option is *not* compatible with  'java_multiple_files = true'
+     * and nested messages since the generated code would produce class name collisions
      * </pre>
      *
      * <code>bool unwrap_builders = 2;</code>

--- a/protoc-gen-kroto-plus/src/main/generated/com/github/marcoferrer/krotoplus/config/ProtoBuildersGenOptionsOrBuilder.java
+++ b/protoc-gen-kroto-plus/src/main/generated/com/github/marcoferrer/krotoplus/config/ProtoBuildersGenOptionsOrBuilder.java
@@ -38,10 +38,11 @@ public interface ProtoBuildersGenOptionsOrBuilder extends
   /**
    * <pre>
    * By default the generated utility methods for building messages are
-   * wrapped in an object similiar to a proto outer class. For better
-   * ergonomics with code generated using 'java_multiple_files' the
+   * wrapped in an object similar to a proto outer class. For better
+   * ergonomics with code generated using 'java_multiple_files = false' the
    * builders can be unwrapped and generated at the root scope of
-   * the output file.
+   * the output file. This option is *not* compatible with  'java_multiple_files = true'
+   * and nested messages since the generated code would produce class name collisions
    * </pre>
    *
    * <code>bool unwrap_builders = 2;</code>

--- a/protoc-gen-kroto-plus/src/main/proto/krotoplus/compiler/config.proto
+++ b/protoc-gen-kroto-plus/src/main/proto/krotoplus/compiler/config.proto
@@ -88,10 +88,11 @@ message ProtoBuildersGenOptions {
     FileFilter filter = 1;
 
     // By default the generated utility methods for building messages are
-    // wrapped in an object similiar to a proto outer class. For better
-    // ergonomics with code generated using 'java_multiple_files' the
+    // wrapped in an object similar to a proto outer class. For better
+    // ergonomics with code generated using 'java_multiple_files = false' the
     // builders can be unwrapped and generated at the root scope of
-    // the output file.
+    // the output file. This option is *not* compatible with  'java_multiple_files = true'
+    // and nested messages since the generated code would produce class name collisions
     bool unwrap_builders = 2;
 
     // Tag java builder classes with a kotlin interface annotated

--- a/test-api/src/main/proto/message/classname_collision.proto
+++ b/test-api/src/main/proto/message/classname_collision.proto
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Kroto+ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package message;
+
+option java_multiple_files = true;
+option java_outer_classname = "ClassNameCollisionProto";
+option java_package = "test.message";
+
+message CollisionMessage {
+
+    message NestedMessage {
+        string some_string = 1;
+        string another_string = 2;
+    }
+
+    repeated NestedMessage nested_messages = 1;
+}
+
+message CollisionSiblingMessage {
+    string locale = 1;
+    string message = 2;
+}


### PR DESCRIPTION
This PR resolves #84 

Unfortunately when the proto builder generator is configured with the option  `unwrap_builders = true`, and `java_multiple_files = true` and any message within the file has a nested message, a class name collisions occurs. 

There isnt much that can be done to fix it without breaking existing user generated code. The best option to resolve the issue is to not use the unwrap builders option and fallback to a static import of the generated builder wrapper object.

The changes introduced in this PR are meant to catch these specific conditions and prevent the generation of invalid code.

Configuration docs have been updated. Warnings are also outputted in the comments of the generated code to let users know when `unwrap_builders` has been deliberately ignored.