### PR TITLE
Fix race in client cancellation propagation

### DIFF
--- a/kroto-plus-coroutines/build.gradle
+++ b/kroto-plus-coroutines/build.gradle
@@ -81,7 +81,7 @@ protobuf {
 }
 
 jacoco {
-    toolVersion = "0.8.3"
+    toolVersion = "0.8.5"
 }
 
 jacocoTestReport {

--- a/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/RpcUtils.kt
+++ b/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/RpcUtils.kt
@@ -22,11 +22,15 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Launch a [Job] within a [ProducerScope] using the supplied channel as the Receiver.
@@ -55,3 +59,13 @@ public fun <T> CoroutineScope.launchProducerJob(
             }
         }
     }
+
+internal suspend fun Channel<*>.awaitCloseOrThrow(){
+    suspendCancellableCoroutine<Unit> { cont ->
+        invokeOnClose { error ->
+            if(error == null)
+                cont.resume(Unit) else
+                cont.resumeWithException(error)
+        }
+    }
+}

--- a/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/client/ClientBidiCallChannel.kt
+++ b/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/client/ClientBidiCallChannel.kt
@@ -19,6 +19,7 @@ package com.github.marcoferrer.krotoplus.coroutines.client
 import com.github.marcoferrer.krotoplus.coroutines.call.FlowControlledInboundStreamObserver
 import com.github.marcoferrer.krotoplus.coroutines.call.MessageHandler
 import com.github.marcoferrer.krotoplus.coroutines.call.applyOutboundFlowControl
+import io.grpc.Status
 import io.grpc.stub.ClientCallStreamObserver
 import io.grpc.stub.ClientResponseObserver
 import kotlinx.coroutines.CancellationException
@@ -96,6 +97,8 @@ internal class ClientBidiCallChannelImpl<ReqT,RespT>(
 
     override val isInboundCompleted = AtomicBoolean()
 
+    private var aborted: Boolean = false
+
     override val transientInboundMessageCount: AtomicInteger = AtomicInteger()
 
     override lateinit var callStreamObserver: ClientCallStreamObserver<ReqT>
@@ -109,8 +112,11 @@ internal class ClientBidiCallChannelImpl<ReqT,RespT>(
         inboundChannel.invokeOnClose {
             // If the client prematurely closes the response channel
             // we need to propagate this as a cancellation to the underlying call
-            if(!outboundChannel.isClosedForSend && coroutineContext[Job]?.isCancelled == false){
-                callStreamObserver.cancel("Client has cancelled call", it)
+            if(!outboundChannel.isClosedForSend && coroutineContext[Job]?.isCancelled == false && !aborted){
+                outboundChannel.close(Status.CANCELLED
+                    .withDescription("Client has cancelled call")
+                    .withCause(it)
+                    .asRuntimeException())
             }
         }
     }
@@ -118,6 +124,7 @@ internal class ClientBidiCallChannelImpl<ReqT,RespT>(
     override fun onNext(value: RespT): Unit = onNextWithBackPressure(value)
 
     override fun onError(t: Throwable) {
+        aborted = true
         outboundChannel.close(t)
         outboundChannel.cancel(CancellationException(t.message,t))
         inboundChannel.close(t)

--- a/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/client/ClientStreamingCallChannel.kt
+++ b/kroto-plus-coroutines/src/main/kotlin/com/github/marcoferrer/krotoplus/coroutines/client/ClientStreamingCallChannel.kt
@@ -18,6 +18,7 @@ package com.github.marcoferrer.krotoplus.coroutines.client
 
 import com.github.marcoferrer.krotoplus.coroutines.call.MessageHandler
 import com.github.marcoferrer.krotoplus.coroutines.call.applyOutboundFlowControl
+import com.github.marcoferrer.krotoplus.coroutines.call.attachOutboundChannelCompletionHandler
 import io.grpc.stub.ClientCallStreamObserver
 import io.grpc.stub.ClientResponseObserver
 import kotlinx.coroutines.CancellationException
@@ -71,6 +72,11 @@ internal class ClientStreamingCallChannelImpl<ReqT,RespT>(
         callStreamObserver = requestStream
         outboundMessageHandler = applyOutboundFlowControl(requestStream, outboundChannel)
 
+        attachOutboundChannelCompletionHandler(
+            callStreamObserver, outboundChannel,
+            onSuccess = { outboundMessageHandler.close() },
+            onError = { error -> completableResponse.completeExceptionally(error) }
+        )
         completableResponse.invokeOnCompletion {
             // If the client prematurely cancels the response
             // we need to propagate this as a cancellation to the underlying call

--- a/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/integration/ClientStreamingBackPressureTests.kt
+++ b/kroto-plus-coroutines/src/test/kotlin/com/github/marcoferrer/krotoplus/coroutines/integration/ClientStreamingBackPressureTests.kt
@@ -201,7 +201,7 @@ class ClientStreamingBackPressureTests {
             )
             requestChannel.close(expectedException)
 
-            assertFailsWithStatus(Status.CANCELLED,"CANCELLED: $expectedCancelMessage"){
+            assertFailsWithStatus(Status.CANCELLED){
                 println(response.await())
             }
         }


### PR DESCRIPTION
Address race condition when prematurely cancelling a call via closing its outbound channel.

Issue reported in #93 